### PR TITLE
useRouteLoaderData で エラーページでも環境変数を取り回せるか検証

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+VITE_HOGE="hogehoge"
+SAMPLE_ENV="sample"

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -4,8 +4,20 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  json,
+  useRouteLoaderData,
+  isRouteErrorResponse,
+  useRouteError,
 } from "@remix-run/react";
-import "./tailwind.css";
+import React from "react";
+
+export const loader = async () => {
+  const SAMPLE_ENV = process.env.SAMPLE_ENV;
+
+  return json({
+    ENV: SAMPLE_ENV
+  })
+};
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -26,5 +38,40 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  return <Outlet />;
+  return (
+    <>
+      <Outlet />
+    </>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const data = useRouteLoaderData<typeof loader>("root")!;
+
+  if(data.ENV) {
+    console.log(data.ENV)
+  }
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div>
+        <h1>
+          {error.status} {error.statusText}
+        </h1>
+        <p>{error.data}</p>
+      </div>
+    );
+  } else if (error instanceof Error) {
+    return (
+      <div>
+        <h1>Error</h1>
+        <p>{error.message}</p>
+        <p>The stack trace is:</p>
+        <pre>{error.stack}</pre>
+      </div>
+    );
+  } else {
+    return <h1>Unknown Error</h1>;
+  }
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,5 @@
 import type { MetaFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
 
 export const meta: MetaFunction = () => {
   return [
@@ -13,34 +14,10 @@ export default function Index() {
       <h1 className="text-3xl">Welcome to Remix</h1>
       <ul className="list-disc mt-4 pl-6 space-y-2">
         <li>
-          <a
-            className="text-blue-700 underline visited:text-purple-900"
-            target="_blank"
-            href="https://remix.run/start/quickstart"
-            rel="noreferrer"
-          >
-            5m Quick Start
-          </a>
+          <Link to={"/hoge"}>hoge</Link>
         </li>
         <li>
-          <a
-            className="text-blue-700 underline visited:text-purple-900"
-            target="_blank"
-            href="https://remix.run/start/tutorial"
-            rel="noreferrer"
-          >
-            30m Tutorial
-          </a>
-        </li>
-        <li>
-          <a
-            className="text-blue-700 underline visited:text-purple-900"
-            target="_blank"
-            href="https://remix.run/docs"
-            rel="noreferrer"
-          >
-            Remix Docs
-          </a>
+          <Link to={"/error"}>error</Link>
         </li>
       </ul>
     </div>

--- a/app/routes/hoge/route.tsx
+++ b/app/routes/hoge/route.tsx
@@ -1,0 +1,54 @@
+import type { MetaFunction } from "@remix-run/node";
+import { 
+  useRouteLoaderData,
+  isRouteErrorResponse,
+  useRouteError,
+} from "@remix-run/react";
+import type { loader } from "~/root";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Hoge Page" },
+    { name: "description", content: "Hoge Hoge" },
+  ];
+};
+
+export default function Hoge() {
+  const data = useRouteLoaderData<typeof loader>("root")!;
+
+  if(data.ENV) {
+    console.log(data.ENV)
+  }
+  return (
+    <div>
+      <h1>hoge</h1>
+    </div>
+  )
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div>
+        <h1>
+          {error.status} {error.statusText}
+        </h1>
+        <p>{error.data}</p>
+        <p>Hoge</p>
+      </div>
+    );
+  } else if (error instanceof Error) {
+    return (
+      <div>
+        <h1>Error</h1>
+        <p>{error.message}</p>
+        <p>The stack trace is:</p>
+        <pre>{error.stack}</pre>
+      </div>
+    );
+  } else {
+    return <h1>Unknown Error</h1>;
+  }
+}


### PR DESCRIPTION
refs:
- #1 

## 概要
useRouteLoaderData で エラーページでも環境変数を取り回せるか検証します。

## レビュー観点
- エラーページのコンソールで`sample` と表示されていること

## 参考URL

https://remix.run/docs/en/main/guides/errors
https://sergiodxa.com/tutorials/access-remix-s-loader-data-from-a-root-errorboundary